### PR TITLE
Fix launch

### DIFF
--- a/tests/terra.ts
+++ b/tests/terra.ts
@@ -74,7 +74,7 @@ export class Terra {
 
   async launch() {
     await expect(this.page.getByRole('button', {name: 'Sign In'})).toHaveCount(0, {timeout: TimeUnits.seconds(30).msec()})
-    await this.page.getByLabel('Environment Configuration').click({timeout: TimeUnits.minutes(1).msec()});
+    await this.page.getByRole('button', { name: 'Environment Configuration' }).click({timeout: TimeUnits.minutes(1).msec()});
     await this.page.getByLabel('GALAXY Environment').click({timeout: TimeUnits.minutes(1).msec()});
     await this.page.getByRole('button', { name: 'Next' }).click();
     await this.page.getByRole('button', { name: 'Create' }).click();


### PR DESCRIPTION
The selector for the 'Environment configuration' button would sometime match more than one element.  Use 'getByRole' rather than 'getByLabel' to be more specific about the element we want to find.